### PR TITLE
Clone versions and MS Docs slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ page_type: sample
 languages:
 - csharp
 products:
-- azure-purview
+- microsoft-purview
 - azure-databricks
 ---
 <!-- markdownlint-disable MD033 - HTML rule -->

--- a/deploy-base.md
+++ b/deploy-base.md
@@ -38,7 +38,9 @@ From the [Azure Portal](https://portal.azure.com)
 
     ```
 
-> **Note**: [See list of supported tags](https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator/tags). Use `git clone https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git` when using the edge version.
+    > **Note**: We highly recommend cloning from [specific release tags listed here](https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator/tags).
+    >
+    > Clone the main branch only when using the edge version.
 
 -----
 

--- a/deploy-base.md
+++ b/deploy-base.md
@@ -34,9 +34,11 @@ From the [Azure Portal](https://portal.azure.com)
 
     ```powershell
     cd clouddrive
-    git clone https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git
+    git clone [-b <version_tag>] https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git
 
     ```
+
+> **Note**: [See list of supported tags](https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator/tags). Use `git clone https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git` when using the edge version.
 
 -----
 

--- a/deploy-demo.md
+++ b/deploy-demo.md
@@ -45,7 +45,9 @@ From the [Azure Portal](https://portal.azure.com)
     git clone [-b <version_tag>] https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git
     ```
 
-> **Note**: [See list of supported tags](https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator/tags). Use `git clone https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git` when using the edge version.
+    > **Note**: We highly recommend cloning from [specific release tags listed here](https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator/tags).
+    >
+    > Clone the main branch only when using the edge version.
 
 ### Configure application settings file
 

--- a/deploy-demo.md
+++ b/deploy-demo.md
@@ -42,8 +42,10 @@ From the [Azure Portal](https://portal.azure.com)
 1. Clone this repository into the clouddrive directory
 
     ```bash
-    git clone https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git
+    git clone [-b <version_tag>] https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git
     ```
+
+> **Note**: [See list of supported tags](https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator/tags). Use `git clone https://github.com/microsoft/Purview-ADB-Lineage-Solution-Accelerator.git` when using the edge version.
 
 ### Configure application settings file
 


### PR DESCRIPTION
1. Updated metadata slug in readme for MS Docs indexing to start picking up the rebrand
2. Added git clone version param to both demo & connector-only...
3. Added note with link to tag lists and clarification about edge version (main branch)