### PR TITLE
Remove Large Query Plans from Events

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ The following app settings are experimental and may be removed in future release
 |----|----|----|
 |useResourceSet|true|Experimental feature|
 |usePurviewTypes|false| Experimental feature|
+|maxQueryPlanSize|null|If the query plan bytes is greater than this value it will be removed from the databricks_process|
 |Spark_Entities|databricks_workspace;databricks_job;databricks_notebook;databricks_notebook_task||
 |Spark_Process|databricks_process||
 |purviewApiEndPoint|{ResourceUri}/catalog/api||

--- a/function-app/adb-to-purview/src/Function.Domain/Models/Parser/Settings/AppConfigurationSettings.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Models/Parser/Settings/AppConfigurationSettings.cs
@@ -36,6 +36,7 @@ namespace Function.Domain.Models.Settings
         public string AuthenticationUri { get; set; } = "purview.azure.net";
         public string AppDomainUrl { get; set; } = "purview.azure.com";
         public string ResourceUri { get; set; } = "https://purview.azure.com";
+        public int maxQueryPlanSize {get; set; } = Int32.MaxValue;
         public string purviewApiEndPoint { get; set; } = "{ResourceUri}/catalog/api";
         public string purviewApiEntityBulkMethod { get; set; } = "/atlas/v2/entity/bulk";
         public string purviewApiEntityByGUIDMethod { get; set; } = "/atlas/v2/entity/guid/";

--- a/function-app/adb-to-purview/src/Function.Domain/Services/OlConsolodateEnrich.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Services/OlConsolodateEnrich.cs
@@ -7,6 +7,8 @@ using Function.Domain.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using Function.Domain.Helpers.Parser;
+using Newtonsoft.Json.Linq;
+using Function.Domain.Models.Settings;
 
 namespace Function.Domain.Services
 {
@@ -21,6 +23,7 @@ namespace Function.Domain.Services
         private readonly ILogger<OlConsolodateEnrich> _logger;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IConfiguration _configuration;
+        private AppConfigurationSettings? _appSettingsConfig = new AppConfigurationSettings();
         private Event _event = new Event();
 
         /// <summary>
@@ -51,6 +54,9 @@ namespace Function.Domain.Services
             try
             {
                 _event = JsonConvert.DeserializeObject<Event>(trimString) ?? new Event();
+                if (System.Text.Encoding.Unicode.GetByteCount(_event.Run.Facets.SparkLogicalPlan.ToString()) > _appSettingsConfig!.maxQueryPlanSize){
+                    _event.Run.Facets.SparkLogicalPlan = new JObject();
+                }
             }
             catch (JsonSerializationException ex) {
                 _logger.LogWarning(ex,$"Unrecognized Message: {strEvent}, error: {ex.Message} path: {ex.Path}");


### PR DESCRIPTION
When enriching the event check to see if the logical plan exceeds the maxQueryPlanSize and drop the plan (not the event) if that's the case