### PR TITLE
Mount Point matching should look for the longest string match

### DIFF
--- a/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/QnParser.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/QnParser.cs
@@ -86,24 +86,16 @@ namespace Function.Domain.Helpers
             string path = "";
             MountPoint? mountPoint;
             string mountPointSource = "";
-            bool gotMountPoint = false;
-            foreach (var dir in potentialMounts)
-            {
-                if (dir != "")
+            // Iterate backwards from the potentialMounts to find
+            // the longest path that matches to a mount point
+            for(int pos = potentialMounts.Length; pos > 0; pos--){
+                potentialMountPoint = string.Join("/", potentialMounts.Take(pos) );
+                if ((mountPoint = _mountsInfo.Where(m => m.MountPointName.Trim('/') == potentialMountPoint.Trim('/')).SingleOrDefault()) != null)
                 {
-                    if (!gotMountPoint)
-                    {
-                        potentialMountPoint += $"/{dir}";
-                        if ((mountPoint = _mountsInfo.Where(m => m.MountPointName.Trim('/') == potentialMountPoint.Trim('/')).SingleOrDefault()) != null)
-                        {
-                            mountPointSource = mountPoint.Source;
-                            gotMountPoint = true;
-                        }
-                    }
-                    else
-                    {
-                        path += $"/{dir}";
-                    }
+                    mountPointSource = mountPoint.Source;
+                    path = "/"+name.Replace(mountPoint.MountPointName.Trim('/'), "");
+                    path.Replace("//","/");
+                    break;
                 }
             }
             return (mountPointSource.Trim('/'), path);

--- a/function-app/adb-to-purview/tests/unit-tests/Function.Domain/Helpers/Parser/QnParserTests.cs
+++ b/function-app/adb-to-purview/tests/unit-tests/Function.Domain/Helpers/Parser/QnParserTests.cs
@@ -77,6 +77,14 @@ namespace UnitTests.Function.Domain.Helpers
         [InlineData("dbfs", 
                     "/mnt/rawdata/retail", 
                     "https://purviewexamplessa.dfs.core.windows.net/rawdata/retail")]  
+        // DBFS mount - Shortest String Match
+        [InlineData("dbfs", 
+                    "/mnt/x/abc", 
+                    "https://xsa.dfs.core.windows.net/x/abc")]  
+        // DBFS mount - Longest String Match
+        [InlineData("dbfs", 
+                    "/mnt/x/y/abc", 
+                    "https://ysa.dfs.core.windows.net/y/abc")]  
         // DBFS mount trailing slash in def
         [InlineData("dbfs", 
                     "/mnt/purview2", 

--- a/function-app/adb-to-purview/tests/unit-tests/Function.Domain/Helpers/Parser/UnitTestData.cs
+++ b/function-app/adb-to-purview/tests/unit-tests/Function.Domain/Helpers/Parser/UnitTestData.cs
@@ -20,7 +20,9 @@ namespace UnitTests.Function.Domain.Helpers
                 new MountPoint(){MountPointName="/mnt/outputdata",Source="abfss://outputdata@purviewexamplessa.dfs.core.windows.net/"},
                 new MountPoint(){MountPointName="/databricks-results",Source="databricks-results"},
                 new MountPoint(){MountPointName="/databricks-results",Source="databricks-results"},
-                new MountPoint(){MountPointName="/mnt/purview2/",Source="abfss://purview2@purviewexamplessa.dfs.core.windows.net/"}
+                new MountPoint(){MountPointName="/mnt/purview2/",Source="abfss://purview2@purviewexamplessa.dfs.core.windows.net/"},
+                new MountPoint(){MountPointName="/mnt/x/",Source="abfss://x@xsa.dfs.core.windows.net/"},
+                new MountPoint(){MountPointName="/mnt/x/y",Source="abfss://y@ysa.dfs.core.windows.net/"}
             };
         }
     }


### PR DESCRIPTION
to solve for cases where two mount points overlap but represent different locations.