### PR TITLE
Update functionapp dependsOn in newdeploymenttemp.json ARM 

### DIFF
--- a/deployment/infra/newdeploymenttemp.json
+++ b/deployment/infra/newdeploymenttemp.json
@@ -125,7 +125,8 @@
 			"tags": "[parameters('resourceTagValues')]",
 			"dependsOn": [
 				"[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-				"[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+				"[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+				"[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
 			],
 			"properties": {
 				"serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",


### PR DESCRIPTION
Added missing Application Insights to ARM dependsOn. The dependsOn should be here because the functionapp has the APPINSIGHTS_INSTRUMENTATIONKEY appsetting which references the Application Insights resource. 

Following the [installation guide ](https://github.com/microsoft/purview-adb-lineage-solution-accelerator/blob/main/deploy-base.md)with existing Azure Databricks and Purview resources stumbles first into this error:
![image](https://user-images.githubusercontent.com/98321903/199110009-0956122b-100a-4210-a044-1502908689f1.png)
When re-run it causes this error:
![image](https://user-images.githubusercontent.com/98321903/199101530-c1b93141-7e9f-4c4c-92ed-cd6afd8cc61c.png)

With this fix, the second error should be fixed. 



