### PR TITLE
Prioritize Resource Sets if High Score in Search Results

### DIFF
--- a/function-app/adb-to-purview/src/Function.Domain/Helpers/PurviewCustomType.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Helpers/PurviewCustomType.cs
@@ -375,7 +375,12 @@ namespace Function.Domain.Helpers
                 {
                     if (qualifiedNameToCompare.ToLower().Trim() == this.to_compare_QualifiedName.ToLower().Trim())
                     {
+                        // In case we have a period in the resource set name, it's pushing the resource set lower
+                        if (entity.SearchScore == 1.0){
+                            validEntities.Insert(0,entity);
+                        } else{
                         validEntities.Add(entity);
+                        }
                     }
                 }
                 else

--- a/function-app/adb-to-purview/src/Function.Domain/Helpers/PurviewCustomType.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Helpers/PurviewCustomType.cs
@@ -361,6 +361,7 @@ namespace Function.Domain.Helpers
         private async Task<List<QueryValeuModel>> SelectReturnEntity(List<QueryValeuModel> results)
         {
             List<QueryValeuModel> validEntities = new List<QueryValeuModel>();
+            bool resourceSetHasBeenSeen = false;
             foreach (QueryValeuModel entity in results)
             {
                 if (IsSpark_Entity(entity.entityType))
@@ -376,12 +377,18 @@ namespace Function.Domain.Helpers
                     if (qualifiedNameToCompare.ToLower().Trim() == this.to_compare_QualifiedName.ToLower().Trim())
                     {
                         // In case we have a period in the resource set name, it's pushing the resource set lower
-                        if (entity.SearchScore == 1.0){
+                        // Only insert the first resource set seen and trust that it is ordered appropriately
+                        // Search score doesn't matter in this case since a search with no keywords and only
+                        // filters will have a 1.0 for all results
+                        if (!(resourceSetHasBeenSeen)){
                             validEntities.Insert(0,entity);
                         } else{
                         validEntities.Add(entity);
                         }
                     }
+                    // Assuming the order of entities are sorted by highest likely match,
+                    // if we 've seen any resource set, it should be the most likely to have matched.
+                    resourceSetHasBeenSeen = true;
                 }
                 else
                 {


### PR DESCRIPTION
Based on Search Score, insert resource sets to the front of the list to avoid missing out on the resource set