### PR TITLE
Handle Azure Data Factory Job Naming Conventions

### DIFF
--- a/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/DatabricksToPurviewParser.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/DatabricksToPurviewParser.cs
@@ -31,7 +31,7 @@ namespace Function.Domain.Helpers
         private readonly EnrichedEvent _eEvent;
         private readonly string _adbWorkspaceUrl;
         const string SETTINGS = "OlToPurviewMappings";
-        Regex ADF_JOB_NAME_REGEX = new Regex(@"^ADF_(.*)_(.*)_(.*)_(.*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex ADF_JOB_NAME_REGEX = new Regex(@"^ADF_(.*)_(.*)_(.*)_(.*)$", RegexOptions.Compiled );
 
         /// <summary>
         /// Constructor for DatabricksToPurviewParser


### PR DESCRIPTION
Truncate Azure Data Factory job name guid to prevent creating duplicate jobs / tasks only differentiated by a guid / pipeline id