### PR TITLE
changes made to the parser code for custom/external hive metastore 

### DIFF
--- a/docs/mappings/README.md
+++ b/docs/mappings/README.md
@@ -21,3 +21,10 @@ This directory contains a "gallery" of sample OpenLineage to Purview Mappings th
     * Supports mapping Snowflake tables in Purview.
     * OpenLineage returns a DataSet with `"namespace":"snowflake://<snowflakeurl>","name":"<database>.<schema>.<table>`
     * Microsoft Purview expects a fully qualified name of `snowflake://<snowflakeurl>/databases/<database>/schemas/<schema>/tables/<table>`
+
+## External hive metastore using azure SQL
+* [external hive metastore](./ext-hive-metastore.json)
+    * Supports mapping hive metastore table hosted in azure sql DB.
+    * OpenLineage returns a hive asset types with `@AdbWorkspaceUrl`
+    * Microsoft Purview expects a fully qualified name of `<database>.<table>@<sqlserver-name>.database.windows.net`
+    * In case of multiple Adb workspace, contains-in or in condition will help to compare multiple values in one single     mapping.

--- a/docs/mappings/ext-hive-metastore.json
+++ b/docs/mappings/ext-hive-metastore.json
@@ -1,0 +1,53 @@
+[
+    {
+        "name": "hiveManagedTableDefault",
+        "parserConditions": [
+            {
+                "op1": "AdbWorkspaceUrl",
+                "compare": "contains-in",
+                "op2": "<adb workspace id1>|<adb workspace id2>|.....<adb workspace idn>"
+            },
+            {
+                "op1": "prefix",
+                "compare": "=",
+                "op2": "dbfs"
+            },
+            {
+                "op1": "nameGroups[0]",
+                "compare": "contains",
+                "op2": "hive/warehouse"
+            }
+        ],
+        "qualifiedName": "default.{nameGroups[0].parts[3]}@<sqlserver-name>.database.windows.net",
+        "purviewDataType": "hive_table",
+        "purviewPrefix": "hive"
+    },
+    {
+        "name": "hiveManagedTableNotDefault",
+        "parserConditions": [
+            {
+                "op1": "AdbWorkspaceUrl",
+                "compare": "contains-in",
+                "op2": "<adb workspace id1>|<adb workspace id2>|.....<adb workspace idn>"
+            },
+            {
+                "op1": "prefix",
+                "compare": "=",
+                "op2": "dbfs"
+            },
+            {
+                "op1": "nameGroups[0]",
+                "compare": "contains",
+                "op2": "hive/warehouse"
+            },
+            {
+                "op1": "nameGroups[0].part",
+                "compare": ">",
+                "op2": "4"
+            }
+        ],
+        "qualifiedName": "{nameGroups[0].part[3]}.{nameGroups[0].part[5]}@<sqlserver-name>.database.windows.net",
+        "purviewDataType": "hive_table",
+        "purviewPrefix": "hive"
+    }
+]

--- a/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/QnParser.cs
+++ b/function-app/adb-to-purview/src/Function.Domain/Helpers/parser/QnParser.cs
@@ -152,6 +152,32 @@ namespace Function.Domain.Helpers
             return true;
         }
 
+        //The function ContainsIn and In will compare all  worspace names. This can be used for custom hive metastore. for first match it will return true
+
+        private bool ContainsIn(string firstOp, string valOp)
+        {
+            var vstrVal = valOp.Split("|");
+            foreach (var item in vstrVal)
+            {
+                if (firstOp.Contains(item)) return true;
+            }
+            return false;
+        }
+
+        private bool In(string firstOp, string valOp)
+        {
+            var vstrVal = valOp.Split("|");
+ 
+            foreach (var item in vstrVal)
+            {
+                if (firstOp == item) return true;
+            }
+ 
+            return false;
+        }
+
+
+
         private bool EvaluateCondition(ParserCondition parserCondition, Dictionary<string,object> olDynParts)
         {
             var firstOp = GetDynamicValue(parserCondition.Op1, olDynParts);
@@ -166,7 +192,11 @@ namespace Function.Domain.Helpers
                 case ">":
                     return int.Parse(firstOp) > int.Parse(parserCondition.ValOp2);
                 case "<":
-                    return int.Parse(firstOp) < int.Parse(parserCondition.ValOp2);                    
+                    return int.Parse(firstOp) < int.Parse(parserCondition.ValOp2); 
+                case "contains-in":
+                    return ContainsIn(firstOp, parserCondition.ValOp2);    
+                case "in":
+                    return In(firstOp, parserCondition.ValOp2);                   
             }
             return false;
         }


### PR DESCRIPTION
Two new condition called 'contains-in' and 'in' added in the parser code.
This will help to compare multiple literals separated by '|' in one mapping. 

Added mapping reference for external hive metastore (both default and not default).